### PR TITLE
Install Boost in Workflow

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -52,7 +52,7 @@ jobs:
       uses: MarkusJx/install-boost@v2.5.1
       with:
         # The boost version to install, e.g. "1.73.0"
-        boost_version: "1.83.0"
+        boost_version: "1.73.0"
         # The toolset used to compile boost, e.g. "msvc"
         toolset: "clang"
         # Whether the boost libraries are linked statically or dynamically

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -52,9 +52,11 @@ jobs:
       uses: MarkusJx/install-boost@v2.5.1
       with:
         # The boost version to install, e.g. "1.73.0"
-        boost_version: "1.83.0"
+        boost_version: 1.83.0
+        platform_version: 20.04
+        version: default
         # The toolset used to compile boost, e.g. "msvc"
-        toolset: "clang"
+        toolset: clang
         # Whether the boost libraries are linked statically or dynamically
         link: static
         # The architecture the binaries were built for

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -52,13 +52,13 @@ jobs:
       uses: MarkusJx/install-boost@v2.5.1
       with:
         # The boost version to install, e.g. "1.73.0"
-        boost_version: "1.73.0"
+        boost_version: "1.83.0"
         # The toolset used to compile boost, e.g. "msvc"
         toolset: "clang"
         # Whether the boost libraries are linked statically or dynamically
         link: static
         # The architecture the binaries were built for
-        arch: aarch64
+        arch: x86
         # Whether to use actions/cache to improve build times
         cache: true
             

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -4,9 +4,9 @@ name: CMake on multiple platforms
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "master" ]
+    branches: [ "main" ]
 
 jobs:
   build:
@@ -17,32 +17,20 @@ jobs:
       fail-fast: false
 
       # Set up a matrix to run the following 3 configurations:
-      # 1. <Windows, Release, latest MSVC compiler toolchain on the default runner image, default generator>
-      # 2. <Linux, Release, latest GCC compiler toolchain on the default runner image, default generator>
-      # 3. <Linux, Release, latest Clang compiler toolchain on the default runner image, default generator>
-      #
+      # 1. <Windows, Release, latest Clang compiler toolchain on the default runner image, default generator>
+      # 2. <Linux, Release, latest Clang compiler toolchain on the default runner image, default generator>
       # To add more build types (Release, Debug, RelWithDebInfo, etc.) customize the build_type list.
       matrix:
         os: [ubuntu-latest, windows-latest]
         build_type: [Release]
-        c_compiler: [gcc, clang, cl]
+        c_compiler: [clang]
         include:
           - os: windows-latest
-            c_compiler: cl
-            cpp_compiler: cl
-          - os: ubuntu-latest
-            c_compiler: gcc
-            cpp_compiler: g++
+            c_compiler: clang
+            cpp_compiler: clang++
           - os: ubuntu-latest
             c_compiler: clang
             cpp_compiler: clang++
-        exclude:
-          - os: windows-latest
-            c_compiler: gcc
-          - os: windows-latest
-            c_compiler: clang
-          - os: ubuntu-latest
-            c_compiler: cl
 
     steps:
     - uses: actions/checkout@v4
@@ -68,9 +56,9 @@ jobs:
         # The toolset used to compile boost, e.g. "msvc"
         toolset: "clang"
         # Whether the boost libraries are linked statically or dynamically
-        link: statically
+        link: static
         # The architecture the binaries were built for
-        arch: x64
+        arch: aarch64
         # Whether to use actions/cache to improve build times
         cache: true
             

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -58,6 +58,23 @@ jobs:
       shell: bash
       run: if [ "$RUNNER_OS" == 'Linux' ]; then sudo apt install libwayland-dev libxkbcommon-dev xorg-dev; fi
 
+    - name: Download and install Boost
+      # You may pin to the exact commit or the version.
+      # uses: MarkusJx/install-boost@8ba8b2fac59ef3d91a838bb4aa53ceabd33d1aa3
+      uses: MarkusJx/install-boost@v2.5.1
+      with:
+        # The boost version to install, e.g. "1.73.0"
+        boost_version: "1.83.0"
+        # The toolset used to compile boost, e.g. "msvc"
+        toolset: "clang"
+        # Whether the boost libraries are linked statically or dynamically
+        link: statically
+        # The architecture the binaries were built for
+        arch: x64
+        # Whether to use actions/cache to improve build times
+        cache: true
+            
+
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type


### PR DESCRIPTION
boost was not installed, leading to the workflow failing every time. this adds a step in the workflow to download and build boost, and to link it statically